### PR TITLE
Fix a bug when creating animated GIF thumbnails with odd width/height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.1 - 2024-08-20
+
+Fix a bug where the tool couldn't create thumbnails of animated GIFs if the thumbnail would have an odd width/height dimension.
+
 ## v1.0.0 - 2024-08-20
 
 Initial release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "create_thumbnail"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "create_thumbnail"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
This is something I made a note of in the associated TIL: https://alexwlchan.net/til/2024/convert-an-animated-gif-to-mp4/

And then I completely forgot when I came to implement this code! Which serves as a validation of the idea of having a single definition of this code.